### PR TITLE
Fix 02 Interactive Computing with ImageStacks.ipynb

### DIFF
--- a/guides/dynamic-compute/02 Interactive Computing with ImageStacks.ipynb
+++ b/guides/dynamic-compute/02 Interactive Computing with ImageStacks.ipynb
@@ -136,6 +136,7 @@
     "    s2_stack_cloudfree = s2_stack.filter(lambda x: x.cloud_fraction < 0.2)\n",
     "except Exception:\n",
     "    # this is the >=1.3.0 dynamic-compute version\n",
+    "    import descarteslabs as dl\n",
     "    s2_stack_cloudfree = s2_stack.filter(dl.catalog.properties.cloud_fraction < 0.2)\n",
     "type(s2_stack_cloudfree)"
    ]


### PR DESCRIPTION
Small PR to fix the Image Stacks guide notebook which was missing an import to work in the try/except block. 

Tested in dev notebook with new client. 